### PR TITLE
Add link to starter kit "create app"

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ By running this code, you'll understand how to:
 
 ## Getting Started
 
+> As an alternative to the steps below, you can [create this project as a starter kit on IBM Cloud](https://console.bluemix.net/developer/appservice/create-app?defaultDeploymentToolchain=&defaultLanguage=NODE&env_id=ibm%3Ayp%3Aus-south&navMode=catalog&starterKit=9bdf6fa6-c750-38c2-8f8e-e90a92f89718), which automatically provisions required services, and injects service credentials into a custom fork of this pattern.
+
 Ensure [IBM Cloud Developer Tools](https://github.com/IBM-Cloud/ibm-cloud-developer-tools) are installed. To install on MacOS and Linux, run:
 
 ```


### PR DESCRIPTION
This is sort of an alternative to the "Deploy to IBM Cloud" button, except "Deploy" is not always the correct term to use with starter kits -- so here's a little blurb instead.

Internal tracking issue: https://github.ibm.com/IBMCode/skit-and-pattern-tracker/issues/13